### PR TITLE
[JS] add design-config support via static config.json

### DIFF
--- a/htdocs/luci-static/design/css/style.css
+++ b/htdocs/luci-static/design/css/style.css
@@ -95,6 +95,103 @@
   }
 }
 
+body.design-dark {
+    --bg: #000;
+    --bgwhite: #000;
+    --text_color: #fefefe;
+    --active_color: #5ea69b;
+    --active_bottom: #51c291 2px solid;
+    --border_color: #2C2C3A;
+    --navbg_color: hsla(0, 0%, 7%, .8);
+    --nav_border: 1px solid #1c1c1e;
+    --sectionbg_color: #1c1c1e;
+    --sectionbg_color2: #1c1c1e;
+    --section_shaddow: 3px 3px 3px rgba(0,0,0,.05);
+    --section_border: none;
+    --sectiontab_border: none;
+    --sectionnode_border: #3d3d41 1px solid;
+    --cbiline_color: #2d2d2d 1px solid;
+    --tabbg_color: #1c1c1e;
+    --tabmenu_border_lr: none;
+    --tabmenubg_color: none;
+    --tabmenu_bottom: #2d2d2d 1px solid;
+    --tabmenu_radius: 6px 6px 0 0;
+    --inputbg_color: #2f2f2f;
+    --inputtext_color: #fefefe;
+    --input_border: 1px solid #4d4d4d;
+    --mainleftbg_color: #000;
+    --bttext_color: #fefefe;
+    --badgebg_color: #fefefe;
+    --badge_border: #3d3d40 1px solid;
+    --progressbar_color: #6d6d6d;
+    --progressbar: #5ea69b;
+    --progressbartxt_color: #fefefe;
+    --logo_color: #fefefe;
+    --alert_color: #ffffff;
+    --alert_background: rgb(30 30 30);
+    --model_background: #2c2c2e;
+    --model_text_color: #fefefe;
+    --scrollbar_color: #4a4a4a;
+}
+
+body.design-light {
+    --bg: #f2f3f5;
+    --bgwhite: #ffffff;
+    --text_color: #333333;
+    --active_color: #42b98a;
+    --active_bottom: #42b98a 2px solid;
+    --border_color: #e6e9ef;
+    --navbg_color: hsla(0, 0%, 100%, .8);
+    --nav_border: 1px solid #e6e9ef;
+    --sectionbg_color: #ffffff;
+    --sectionbg_color2: #f8f9fa;
+    --section_shaddow: 3px 3px 3px rgba(0,0,0,.04);
+    --section_border: 1px solid #e6e9ef;
+    --sectiontab_border: 1px solid #e6e9ef;
+    --sectionnode_border: #e6e9ef 1px solid;
+    --cbiline_color: #f0f0f0 1px solid;
+    --tabbg_color: #ffffff;
+    --tabmenu_border_lr: 1px solid #e6e9ef;
+    --tabmenubg_color: #ffffff;
+    --tabmenu_bottom: #e6e9ef 1px solid;
+    --tabmenu_radius: 6px 6px 0 0;
+    --inputbg_color: #ffffff;
+    --inputtext_color: #333333;
+    --input_border: 1px solid #dcdfe6;
+    --mainleftbg_color: #f2f3f5;
+    --bttext_color: #333333;
+    --badgebg_color: #333333;
+    --badge_border: #e6e9ef 1px solid;
+    --progressbar_color: #e6e9ef;
+    --progressbar: #42b98a;
+    --progressbartxt_color: #333333;
+    --logo_color: #333333;
+    --alert_color: #000000;
+    --alert_background: rgb(230 230 230);
+    --model_background: #ffffff;
+    --model_text_color: #333333;
+    --scrollbar_color: #d0d0d0;
+}
+
+html, body {
+    background-image: var(--bg-image, none);
+    background-size: cover;
+    background-attachment: fixed;
+    background-position: center;
+}
+
+body.design-wallpaper header {
+    background-color: var(--navbg_color);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+}
+
+body.design-wallpaper .main > .main-left {
+    background-color: var(--navbg_color);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+}
+
 @font-face {
     font-family: 'icomoon';
     src: url('../fonts/font.woff') format('woff'),

--- a/htdocs/luci-static/resources/menu-design.js
+++ b/htdocs/luci-static/resources/menu-design.js
@@ -11,7 +11,55 @@ var LuciCompat = {
 
 return baseclass.extend({
 	__init__: function() {
+		this.applyDesignConfig();
 		ui.menu.load().then(L.bind(this.render, this));
+	},
+
+	applyDesignConfig: function() {
+		fetch('/luci-static/design/config.json?_=' + Date.now())
+			.then(function(r) { return r.ok ? r.json() : null; })
+			.catch(function() { return null; })
+			.then(function(cfg) {
+				if (!cfg) return;
+				var body = document.body;
+				var root = document.documentElement;
+
+				if (cfg.mode === 'dark') {
+					body.classList.add('design-dark');
+					body.classList.remove('design-light');
+				} else if (cfg.mode === 'light') {
+					body.classList.add('design-light');
+					body.classList.remove('design-dark');
+				}
+
+				var navbar = document.querySelector('.navbar');
+				if (navbar) {
+					navbar.style.display = (cfg.navbar === 'close') ? 'none' : '';
+				}
+
+				if (cfg.navbar_proxy) {
+					var proxyLinks = document.querySelectorAll('.navbar a[href*="/services/"]');
+					proxyLinks.forEach(function(a) {
+						a.href = a.href.replace(/\/services\/[^/]+/, '/services/' + cfg.navbar_proxy);
+						var img = a.querySelector('img');
+						if (img) img.src = img.src.replace(/\/images\/[^/]+\.png/, '/images/' + cfg.navbar_proxy + '.png');
+					});
+				}
+
+				if (cfg.accent_color && /^#[0-9a-fA-F]{3,6}$/.test(cfg.accent_color)) {
+					root.style.setProperty('--active_color', cfg.accent_color);
+					root.style.setProperty('--progressbar', cfg.accent_color);
+				}
+
+				if (cfg.bg_color && /^#[0-9a-fA-F]{3,6}$/.test(cfg.bg_color)) {
+					root.style.setProperty('--bg', cfg.bg_color);
+				}
+
+				if (cfg.wallpaper_url && /^(https?:\/\/|\/)/.test(cfg.wallpaper_url)) {
+					root.style.setProperty('--bg-image', "url('" + cfg.wallpaper_url + "')");
+					body.classList.add('design-wallpaper');
+				}
+			});
 	},
 
 	render: function(tree) {


### PR DESCRIPTION
This PR adds full compatibility with luci-app-design-config by using a pure-JS approach.

## Approach

Instead of reading UCI on the Lua/server side, `luci-app-design-config` writes a static `/www/luci-static/design/config.json` file on every save. This file is publicly accessible without a session, so the login page also gets the correct theme.

## Changes

### `menu-design.js`
- Added `applyDesignConfig()` called from `__init__`
- `fetch`es `/luci-static/design/config.json` (no auth required)
- Applies:
  - `mode`: adds `design-dark` or `design-light` class to `<body>`
  - `navbar`: hides/shows the `.navbar` element
  - `navbar_proxy`: updates proxy link href and icon src
  - `accent_color`: overrides `--active_color` and `--progressbar` CSS variables
  - `bg_color`: overrides `--bg` CSS variable
  - `wallpaper_url`: sets `--bg-image` and adds `design-wallpaper` class

### `style.css`
- Added `body.design-dark` and `body.design-light` variable blocks (higher specificity than `@media` `:root`, so forced mode overrides system preference)
- Added `html, body { background-image: var(--bg-image, none) }` for wallpaper support
- Added `body.design-wallpaper` backdrop-filter rules for header and sidebar

## No changes to `header.htm`
The Lua template is untouched — all logic is in JS.